### PR TITLE
Death to default scope

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,6 +41,27 @@ If you want to improve immortal
 
 ## CHANGELOG
 
+- 2.0.0 [WARNING NON-BACKWARDS COMPATIBLE RELEASE]
+
+  The major new feature here is we've removed the default_scope.
+
+  To get find to NOT return records marked as deleted by immortal, 
+  you now need to be explicit and use the supplied 'without_deleted' scope.
+
+    Task.without_deleted.first
+
+  If you want all records then don't bother with the scope:
+
+    Task.first
+
+  If you only want deleted records use the 'only_deleted' scope.
+
+    Task.only_deleted.first
+
+  The 'with_deleted' scope is no longer.
+
+  See the updated specs for a feel of what using immortal is like now.
+
 - 1.0.5 Use separate internal accessors for with/only_deleted singular association readers
 - 1.0.4 Extract with_deleted singular assoc readers to separate module
 - 1.0.3 Added back feature where using immortal finders doesn't unscope association scopes.

--- a/immortal.gemspec
+++ b/immortal.gemspec
@@ -3,12 +3,12 @@ $:.push File.expand_path("../lib", __FILE__)
 
 Gem::Specification.new do |s|
   s.name        = "immortal"
-  s.version     = '1.0.5'
+  s.version     = '2.0.0'
   s.authors     = ["Jordi Romero", "Saimon Moore"]
   s.email       = ["jordi@jrom.net", "saimon@saimonmoore.net"]
   s.homepage    = "http://github.com/teambox/immortal"
-  s.summary     = %q{Replacement for acts_as_paranoid for Rails 3}
-  s.description = %q{Typical paranoid gem built for Rails 3 and with the minimum code needed to satisfy acts_as_paranoid's API}
+  s.summary     = %q{Non-standard replacement for acts_as_paranoid for Rails 3}
+  s.description = %q{A new more explicity take on the typical aranoid gem built for Rails 3. Built with the minimum code needed to satisfy acts_as_paranoid's API but more explicit. (i.e. no default_scope)}
 
   s.files         = `git ls-files`.split("\n")
   s.test_files    = `git ls-files -- {spec}/*`.split("\n")

--- a/lib/immortal/belongs_to_builder.rb
+++ b/lib/immortal/belongs_to_builder.rb
@@ -12,17 +12,17 @@ module Immortal
     private
 
       def define_deletables
-        define_with_deleted_reader
+        define_without_deleted_reader
         define_only_deleted_reader
       end
 
-      def define_with_deleted_reader
+      def define_without_deleted_reader
         name = self.name
 
-        model.redefine_method("#{name}_with_deleted") do |*params|
+        model.redefine_method("#{name}_without_deleted") do |*params|
           assoc = association(name)
           assoc.send(:extend, SingularAssociation)
-          assoc.with_deleted_reader(*params)
+          assoc.without_deleted_reader(*params)
         end
       end
 

--- a/lib/immortal/relation.rb
+++ b/lib/immortal/relation.rb
@@ -1,0 +1,53 @@
+require 'active_record/identity_map'
+
+module Immortal
+  module Relation
+
+    def self.included(base)
+      base.class_eval do
+        alias_method_chain :delete_all, :immortal
+      end
+    end
+
+    def delete_all_with_immortal(conditions = nil)
+      ActiveRecord::IdentityMap.repository[symbolized_base_class] = {} if ActiveRecord::IdentityMap.enabled?
+      if conditions
+        where(conditions).delete_all
+      else
+        # This method is called in various places e.g
+        # both by AR::Base#destroy and by AR::CollectionAssociation#delete_or_destroy
+        # which handles deletion of dependant collections.
+        #
+        # In the latter case, when this method is called the
+        # association has already been marked as deleted.
+        # 
+        # Without this code (and without the previous immortal default_scope)
+        # the default behaviour was to delete the records directly via the db.
+        # 
+        # When we had the immortal default_scope,
+        # load_target (a sub method used AR::CollectionAssociation#delete) would
+        # not load the associations to be deleted as they were already marked as
+        # deleted and thus filtered out by the default scope.
+        #
+        # So we have to filter AR::Relation.delete_all by only non-deleted records.
+        #
+        # The perhaps unwanted side-effect of this is
+        # you can NEVER #delete_all #destroy any records that have been
+        # marked as deleted. I don't see this as a huge issue though.
+        #
+        # In the former case, the initial implementation of this method was:
+        #
+        #     update_all({:deleted => true})
+        #
+        # which is not what AR::Base#destroy is expected to do so hence
+        # this code.
+        statement = self.where(arel_table[:deleted].eq(nil).or(arel_table[:deleted].eq(false))).arel.compile_delete
+        affected = @klass.connection.delete(statement, 'SQL', bind_values)
+
+        reset
+        affected
+      end
+    end
+
+  end
+end


### PR DESCRIPTION
- 2.0.0 [WARNING NON-BACKWARDS COMPATIBLE RELEASE]
  
  The major new feature here is we've removed the default_scope.
  
  To get find to NOT return records marked as deleted by immortal, 
  you now need to be explicit and use the supplied 'without_deleted' scope.
  
    Task.without_deleted.first
  
  If you want all records then don't bother with the scope:
  
    Task.first
  
  If you only want deleted records use the 'only_deleted' scope.
  
    Task.only_deleted.first
  
  The 'with_deleted' scope is no longer.
  
  See the updated specs for a feel of what using immortal is like now.
