### PR TITLE
Fix rake tasks to create tables like schema:load

### DIFF
--- a/lib/immortal.rb
+++ b/lib/immortal.rb
@@ -99,7 +99,7 @@ module Immortal
 
   module InstanceMethods
     def self.included(base)
-      unless base.columns_hash["deleted"] && !base.columns_hash["deleted"].null
+      unless base.table_exists? && base.columns_hash["deleted"] && !base.columns_hash["deleted"].null
         Kernel.warn "[Immortal] The 'deleted' column in #{base.to_s} is nullable, change the column to not accept NULL values"
       end
 


### PR DESCRIPTION
I you recreate the database it will try to check the columns but the table does not exists 

![](http://24.media.tumblr.com/c5c3f83f34b5726bae5e7d70a82cce02/tumblr_n1kn0hEcGO1s373hwo1_400.gif)
