### PR TITLE
Fixed immortal not running after commit callbacks after a successful `destroy`

### DIFF
--- a/lib/immortal.rb
+++ b/lib/immortal.rb
@@ -115,6 +115,7 @@ module Immortal
       run_callbacks :destroy do
         destroy_without_callbacks
       end
+      run_callbacks :commit
     end
 
     def destroy!

--- a/lib/immortal.rb
+++ b/lib/immortal.rb
@@ -124,12 +124,14 @@ module Immortal
 
     def destroy_without_callbacks
       self.class.unscoped.update_all({ :deleted => true }, "id = #{self.id}")
+      @destroyed = true
       reload
       freeze
     end
 
     def recover!
       self.class.unscoped.update_all({ :deleted => false }, "id = #{self.id}")
+      @destroyed = false
       reload
     end
 

--- a/lib/immortal.rb
+++ b/lib/immortal.rb
@@ -112,10 +112,11 @@ module Immortal
     end
 
     def immortal_destroy
-      run_callbacks :destroy do
-        destroy_without_callbacks
+      with_transaction_returning_status do
+        run_callbacks :destroy do
+          destroy_without_callbacks
+        end
       end
-      run_callbacks :commit
     end
 
     def destroy!

--- a/spec/immortal_spec.rb
+++ b/spec/immortal_spec.rb
@@ -106,6 +106,12 @@ describe Immortal do
     @m.after_d.should be_true
   end
 
+  it "should execute the after_commit callback when immortally destroyed" do
+    @m.after_commit = false
+    @m.destroy
+    @m.after_commit.should be_true
+  end
+
   it "should not execute the before_update callback when immortally destroyed" do
     @m.destroy
     @m.before_u.should be_nil

--- a/spec/immortal_spec.rb
+++ b/spec/immortal_spec.rb
@@ -112,6 +112,13 @@ describe Immortal do
     @m.after_commit.should be_true
   end
 
+  it "should not return true when a before hook halts" do
+    @m.before_return = false
+    @m.after_commit = false
+    @m.destroy.should be_false
+    @m.after_commit.should_not be_true
+  end
+
   it "should not execute the before_update callback when immortally destroyed" do
     @m.destroy
     @m.before_u.should be_nil

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -113,7 +113,7 @@ class ImmortalModel < ActiveRecord::Base
   after_destroy    :set_after
   before_update    :set_before_update
   after_update     :set_after_update
-  after_commit     :set_after_commit
+  after_commit     :set_after_commit, on: :destroy
 
   private
 

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -107,7 +107,7 @@ class ImmortalModel < ActiveRecord::Base
   has_many :joins, :class_name => 'ImmortalJoin', :dependent => :delete_all
   has_many :nodes, :through => :joins, :source => :immortal_node, :dependent => :destroy
 
-  attr_accessor :before_d, :after_d, :before_u, :after_u, :after_commit
+  attr_accessor :before_d, :after_d, :before_u, :after_u, :after_commit, :before_return
 
   before_destroy   :set_before
   after_destroy    :set_after
@@ -119,6 +119,7 @@ class ImmortalModel < ActiveRecord::Base
 
   def set_before
     @before_d = true
+    @before_return
   end
 
   def set_after

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -107,14 +107,16 @@ class ImmortalModel < ActiveRecord::Base
   has_many :joins, :class_name => 'ImmortalJoin', :dependent => :delete_all
   has_many :nodes, :through => :joins, :source => :immortal_node, :dependent => :destroy
 
-  attr_accessor :before_d, :after_d, :before_u, :after_u
+  attr_accessor :before_d, :after_d, :before_u, :after_u, :after_commit
 
   before_destroy   :set_before
   after_destroy    :set_after
   before_update    :set_before_update
   after_update     :set_after_update
+  after_commit     :set_after_commit
 
   private
+
   def set_before
     @before_d = true
   end
@@ -125,6 +127,10 @@ class ImmortalModel < ActiveRecord::Base
 
   def set_after_update
     @after_u = true
+  end
+
+  def set_after_commit
+    @after_commit = true
   end
 
   def set_before_update


### PR DESCRIPTION
#### :tophat: What? Why?

Immortal does an `update_all` that does not trigger `after_commit` callbacks. This makes all code on an `after_commit` callback to not be ever run if the model is immortal.

#### :ghost: GIF
![](https://i.4cdn.org/wsg/1424118720501.gif)