### PR TITLE
Added recreate! method

### DIFF
--- a/lib/immortal.rb
+++ b/lib/immortal.rb
@@ -136,6 +136,19 @@ module Immortal
       reload
     end
 
+    def recreate!
+      with_transaction_returning_status do
+        run_callbacks :create do
+          self.class.unscoped.update_all({
+            deleted: false,
+            updated_at: current_time_from_proper_timezone,
+            created_at: current_time_from_proper_timezone }, "id = #{self.id}")
+          @destroyed = false
+          reload
+        end
+      end
+    end
+
     private
 
     def current_time_from_proper_timezone

--- a/spec/immortal_spec.rb
+++ b/spec/immortal_spec.rb
@@ -175,6 +175,35 @@ describe Immortal do
     ImmortalModel.first.should == @m
   end
 
+  it "updates updated_at with recreate!" do
+    @m.destroy
+    @m = ImmortalModel.find_with_deleted(@m.id)
+    expect {
+      @m.recreate!
+    }.to change(@m, :updated_at)
+    @m.should_not be_frozen
+    @m.should_not be_changed
+    ImmortalModel.first.should == @m
+  end
+
+  it "updates created_at with recreate!" do
+    @m.destroy
+    @m = ImmortalModel.find_with_deleted(@m.id)
+    expect {
+      @m.recreate!
+    }.to change(@m, :created_at)
+    @m.should_not be_frozen
+    @m.should_not be_changed
+    ImmortalModel.first.should == @m
+  end
+
+  it "runs create callbacks with recreate!" do
+    @m.destroy
+    @m = ImmortalModel.find_with_deleted(@m.id)
+    @m.recreate!
+    @m.after_c.should be_true
+  end
+
   it "should consider an Many-to-many association with through as deleted when the join is deleted." do
     @n = ImmortalNode.create! :title => 'testing association'
     @join = ImmortalJoin.create! :immortal_model => @m, :immortal_node => @n

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -78,7 +78,7 @@ class ImmortalNode < ActiveRecord::Base
 
   has_many :immortal_joins
   has_many :immortal_models, :through => :immortal_joins
-  
+
   has_many :joins, :class_name => 'ImmortalJoin'
   has_many :models, :through => :joins, :source => :immortal_model
 
@@ -107,10 +107,11 @@ class ImmortalModel < ActiveRecord::Base
   has_many :joins, :class_name => 'ImmortalJoin', :dependent => :delete_all
   has_many :nodes, :through => :joins, :source => :immortal_node, :dependent => :destroy
 
-  attr_accessor :before_d, :after_d, :before_u, :after_u, :after_commit, :before_return
+  attr_accessor :before_d, :after_d, :before_u, :after_u, :after_c, :after_commit, :before_return
 
   before_destroy   :set_before
   after_destroy    :set_after
+  after_create     :set_after_create
   before_update    :set_before_update
   after_update     :set_after_update
   after_commit     :set_after_commit, on: :destroy
@@ -138,6 +139,9 @@ class ImmortalModel < ActiveRecord::Base
     @before_u = true
   end
 
+  def set_after_create
+    @after_c = true
+  end
 end
 
 class ImmortalNullableDeleted < ActiveRecord::Base


### PR DESCRIPTION
Sometimes you have unique indexes that doesn't allow you to create a new model and you need to "recreate" from immortal. Immortal provides the `recover!` method but it does not trigger any callback. 